### PR TITLE
Scripts to replace nodes in a DC/OS cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# README
+
+This repository contains scripts to perform a node replacement on a DC/OS
+cluster. It uses the `dcos` CLI tool to communicate with a DC/OS cluster
+and the `aws` CLI tool to communicate with AWS. It's assumed that AWS
+credentials have already been fetched or this is running on an instance
+with an instance profile capable of performing the EC2 actions.
+
+## Quick Start
+
+It's not required to export username and password, unless you want to
+run without interaction.
+
+```
+export DCOS_USERNAME=<username>
+export DCOS_PASSWORD=<password>
+
+./dcos_cluster_setup.sh <master_url>
+./runner
+```
+
+## Order
+
+### Sanity
+
+* `dcos_sanity_check zookeeper` returns 0
+* `dcos_sanity_check leader` returns 0
+
+### Preparation
+
+* Run core-infrastructure
+* `dcos_backup.sh` to start backup (wait for it to complete)
+
+### Masters
+
+* Remove 1 non-leader master
+  * `dcos_sanity_check.sh cockroachdb` return 0
+  * `dcos_sanity_check.sh master_snapshot` return 0
+* Remove another non-leader master
+  * `dcos_sanity_check.sh cockroachdb` return 0
+  * `dcos_sanity_check.sh master_snapshot` return 0
+* Remove former leader
+  * `dcos_sanity_check.sh cockroachdb` return 0
+  * `dcos_sanity_check.sh master_snapshot` return 0
+
+### Agents
+
+* Get zone list from `dcos_cluster_zones.sh`
+
+#### Per-zone
+
+* Get agent IPs: `dcos_agents_by_zone.sh <zone>`
+* For each IP: `aws_terminate.sh` <ip>
+* Wait for agents up using `dcos_agents_by_zone.sh <zone>`
+

--- a/aws_terminate.sh
+++ b/aws_terminate.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+#
+# aws_instance_id <ip>
+#
+# returns an instance ID from a given IP address
+function aws_instance_id() {
+  local readonly __ip=${1} __region=${2:-us-east-1}
+  aws ec2 describe-instances --region=${__region} \
+    --filters "Name=private-ip-address,Values=${__ip}" \
+    --query "Reservations[].Instances[].InstanceId|[0]" | \
+    tr -d '"'
+}
+
+#
+# aws_instance_state <id> [region]
+#
+# return the state of an AWS instance
+function aws_instance_state() {
+  local readonly __id=${1} __region=${2:-us-east-1}
+  aws ec2 describe-instances --region=${__region} --filters "Name=instance-id,Values=${__id}" \
+    --query "Reservations[].Instances[].State.Name|[0]" | \
+    tr -d '"'
+}
+
+#
+# aws_until_state <state> <id> [timeout]
+#
+# polls instance until given state, with back-off and timeout
+function aws_until_state() {
+  local readonly __state=${1} __id=${2} __timeout=${3:-60} __backoff=0 __ret=0
+  until [[ $(aws_instance_state ${__id}) == ${__state} ]] || [[ ${__backoff} -ge ${__timeout} ]]; do
+    sleep $(( __backoff++ ))
+  done
+  __ret=$?
+  if [[ ${__backoff} -ge ${__timeout} ]]; then
+    return 1
+  fi
+  return ${__ret}
+}
+
+#
+# aws_terminate <ip> [timeout]
+#
+# Terminates a given instance by its IP address
+function aws_terminate() {
+  local readonly __ip=${1} __timeout=${2:-120}
+  local __dry_run __id __result __ret
+  [[ ${DRY_RUN} ]] && __dry_run="--dry-run"
+  __id=$(aws_instance_id ${__ip})
+  ### TODO: region is hard-coded here... improve
+  __result=$(aws ec2 terminate-instances --region=us-east-1 --instance-ids ${__id} ${__dry_run} 2>&1 >/dev/null)
+  __ret=$?
+  if [[ ${__ret} -eq 255 ]]; then
+    echo "User specified DRY_RUN... skipping"
+    return # do nothing, as we're in a dry-run
+  elif [[ ${__ret} -ne 0 ]]; then
+    return ${__ret}
+  fi
+  aws_until_state terminated ${__id} ${__timeout} || return $?
+}
+
+aws_terminate ${@}

--- a/dcos_agents.sh
+++ b/dcos_agents.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#
+# dcos_agents
+#
+# returns the DC/OS agent IP addresses
+function dcos_agents() { dcos node | awk '/agent/ {print $2}'; };
+
+dcos_agents

--- a/dcos_agents_by_zone.sh
+++ b/dcos_agents_by_zone.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#
+# dcos_agents_by_zone <zone>
+#
+# returns a list of DC/OS agent IP addresses within a given zone
+dcos_agents_by_zone() { dcos node | grep agent | grep ${1} | awk '{print $2}'; };
+
+dcos_agents_by_zone ${@}

--- a/dcos_auth.sh
+++ b/dcos_auth.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+export DCOS_USERNAME=${DCOS_USERNAME}
+export DCOS_PASSWORD=${DCOS_PASSWORD}
+
+#
+# dcos_auth <cluster>
+#
+# Authorizes a session against the given cluster
+function dcos_auth() {
+  local readonly __cluster=${1}
+  if [[ $(dcos config show cluster.name) != ${1} ]]; then
+    dcos cluster attach ${1} || return 1
+  fi
+  dcos auth login --username=${DCOS_USERNAME} --password-env=DCOS_PASSWORD
+}
+
+dcos_auth ${@}

--- a/dcos_backup.sh
+++ b/dcos_backup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Install/upgrade DC/OS Enterprise CLI
+dcos package install dcos-enterprise-cli --yes 2>&1 >/dev/null
+
+#
+# dcos_backup_ready <label> [timeout]
+#
+# Wait for backup to complete, with back-off and timeout
+function dcos_backup_ready() {
+  local readonly __label=${1} __timeout=${2:-60}
+  local __backoff=0
+  until dcos backup list ${__label} | grep ${__label} | awk '{print $3}' | grep STATUS_READY >/dev/null || [[ ${__backoff} -ge ${__timeout} ]]; do
+    sleep $(( __backoff++ ))
+  done
+}
+
+#
+# dcos_backup [label]
+#
+# Creates a backup, returns 0 on success, 1 on failure to schedule, 2 on failure to backup
+dcos_backup() {
+  local readonly __label=${1:-bu-$(date +%s)}
+  local __ret
+  dcos backup create --label=${__label} || return 1
+  dcos_backup_ready ${__label} || return 2
+}
+
+dcos_backup ${@}

--- a/dcos_cluster_setup.sh
+++ b/dcos_cluster_setup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+export DCOS_USERNAME=${DCOS_USERNAME}
+export DCOS_PASSWORD=${DCOS_PASSWORD}
+
+#
+# dcos_cli_install [version]
+#
+# Fetches the dcos CLI
+function dcos_cli_install() {
+  local readonly __version=${1:-1.11}
+  local __os
+  if [[ $(type -P dcos) ]]; then
+    return 0
+  fi
+  [[ -d /usr/local/bin ]] || sudo mkdir -p /usr/local/bin
+  case $(uname -s) in
+    *inux) __os="linux" ;;
+    *arwin) __os="darwin" ;;
+    *) return 1 ;;
+  esac
+  curl https://downloads.dcos.io/binaries/cli/${__os}/x86-64/dcos-${__version}/dcos > /tmp/dcos-${__os} || return 1
+  sudo mv -f /tmp/dcos-${__os} /usr/local/bin/dcos || return 1
+  sudo chmod 755 /usr/local/bin/dcos || return 1
+  return 0
+}
+
+#
+# dcos_cluster_setup <master>
+#
+# Configures a cluster given a master address
+function dcos_cluster_setup() {
+  local readonly __master=${1}
+  dcos_cli_install || return 1
+  dcos cluster setup ${__master} --no-check --username=${DCOS_USERNAME} --password-env=DCOS_PASSWORD
+}
+
+dcos_cluster_setup ${@}

--- a/dcos_cluster_zones.sh
+++ b/dcos_cluster_zones.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#
+# dcos_cluster_zones
+#
+# returns a list of zones for DC/OS agents
+function dcos_cluster_zones() { dcos node | grep agent | awk '{print $6}' | sort -u; };
+
+dcos_cluster_zones

--- a/dcos_decommission_agent.sh
+++ b/dcos_decommission_agent.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#
+# dcos_agent_mesos_id <ip>
+#
+# returns the Mesos ID of an agent, given an IP
+dcos_agent_mesos_id() { dcos node | grep agent | grep ${1} | awk '{print $3}'; };
+
+#
+# dcos_decommission_agent <ip>
+#
+# decommissions a node, if it exists
+dcos_decommission_agent() {
+  local readonly __ip=${1}
+  local __output __ret=0
+  __output=$(dcos_agent_mesos_id ${__ip} 2>/dev/null)
+  __ret=$?
+  if [[ ${__ret} -ne 0 ]]; then
+    return ${__ret}
+  fi
+  if [[ ${__output} ]]; then
+    dcos node decommission ${__output}
+    __ret=$?
+  fi
+  return 0
+}
+
+dcos_decommission_agent ${@}

--- a/dcos_leader.sh
+++ b/dcos_leader.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#
+# dcos_leader
+#
+# returns DC/OS leader IP
+function dcos_leader() { dcos node | grep leader | awk '{print $2}'; };
+
+dcos_leader

--- a/dcos_masters.sh
+++ b/dcos_masters.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#
+# dcos_masters
+#
+# returns the list of DC/OS masters
+function dcos_masters() { dcos node | grep master | awk '{print $2}'; };
+
+dcos_masters

--- a/dcos_sanity_check.sh
+++ b/dcos_sanity_check.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+#
+# dcos_agent_snapshot_sanity <ip>
+#
+# Verifies the sanity of agent snapshot
+function dcos_agent_snapshot_sanity() {
+  local readonly __ip=${1}
+  local __output __ret=0
+  __output=$($(pwd -P)/dcos_ssh.sh ${__ip} "curl -fsSL http://${__ip}:5051/metrics/snapshot" 2>/dev/null)
+  __ret=$?
+  if [[ ${__ret} -ne 0 ]]; then
+    return ${__ret}
+  fi
+  # Fail if we're not registered
+  if [[ $(echo ${__output} | jq '."slave/registered"') -ne 1 ]]; then
+    return 1
+  fi
+  return 0
+}
+
+#
+# dcos_cockroach_sanity <ip>
+#
+# Verifies the sanity of a cockroachdb
+function dcos_cockroach_sanity() {
+  local readonly __ip=${1}
+  $(pwd -P)/dcos_ssh.sh ${__ip} "sudo /opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/cockroach --host=${__ip} --format=csv" 2>/dev/null | grep -v '^#' | tail -n +2 | rev | cut -d, -f1 | rev
+}
+
+#
+# dcos_leader_sanity <ip>
+#
+# Verifies the sanity of leader.mesos DNS entry
+function dcos_leader_sanity() {
+  local readonly __ip=${1} __leader=$($(pwd -P)/dcos_leader.sh)
+  local __output __ret=0
+  __output=$($(pwd -P)/dcos_ssh.sh ${__ip} "host leader.mesos" 2>/dev/null | awk '{print $4}' | head -n 1)
+  __ret=$?
+  if [[ ${__ret} -ne 0 ]]; then
+    return ${__ret}
+  fi
+  if [[ ${__output} != ${__leader} ]]; then
+    return 1
+  fi
+  return 0
+}
+
+#
+# dcos_master_snapshot_sanity <ip>
+#
+# Verifies the sanity of master snapshot
+function dcos_master_snapshot_sanity() {
+  local readonly __ip=${1}
+  local __output __ret=0
+  __output=$($(pwd -P)/dcos_ssh.sh ${__ip} "curl -fsSL http://${__ip}:5050/metrics/snapshot" 2>/dev/null)
+  __ret=$?
+  if [[ ${__ret} -ne 0 ]]; then
+    return ${__ret}
+  fi
+  # Fail if we're not recovered
+  if [[ $(echo ${__output} | jq '."registrar/log/recovered"') -ne 1 ]]; then
+    return 1
+  fi
+  return 0
+}
+
+#
+# dcos_zookeeper_sanity <ip>
+#
+# Verifies the sanity of ZooKeeper
+function dcos_zookeeper_sanity() {
+  local readonly __ip=${1}
+  local __output __ret=0
+  __output=$($(pwd -P)/dcos_ssh.sh ${__ip} "curl -fsSL http://localhost:8181/exhibitor/v1/cluster/status" 2>/dev/null)
+  __ret=$?
+  if [[ ${__ret} -ne 0 ]]; then
+    return ${__ret}
+  fi
+  # Fail if master isn't serving
+  if [[ $(echo ${__output} | jq ".[] | select(.hostname == \"${__ip}\") | .description" | sed 's/"//g') != 'serving' ]]; then
+    return 1
+  fi
+  if [[ $(echo ${__output} | jq ".[] | select(.hostname == \"${__ip}\") | .isLeader") == true ]]; then
+    # We're a leader, so output true
+    echo true
+  else
+    echo false
+  fi
+  return 0
+}
+
+#
+# dcos_sanity_check <check>
+#
+# Verifies the sanity of a given check type
+function dcos_sanity_check() {
+  local readonly __check=${1}
+  local __failed=0
+  case ${__check} in
+    agent_snapshot)
+      local readonly __agents=$($(pwd -P)/dcos_agents.sh)
+      local __host
+      for __host in ${__agents}; do
+        dcos_agent_snapshot_sanity ${__host} || return $?
+      done
+      return 0 # redundant, but explicit
+    ;;
+    cockroachdb)
+      local readonly __masters=$($(pwd -P)/dcos_masters.sh)
+      local __host __output __ret=0
+      for __host in ${__masters}; do
+        for __output in $(dcos_cockroach_sanity ${__host}); do
+          __ret=$?
+          if [[ ${__ret} -ne 0 ]]; then
+            return ${__ret}
+          fi
+          if [[ ${__output} -ne 0 ]]; then
+            __failed=1
+            break
+          fi
+        done
+        if [[ ${__failed} -ne 0 ]]; then
+          break
+        fi
+      done
+      return ${__failed}
+    ;;
+    leader)
+      local readonly __masters=$($(pwd -P)/dcos_masters.sh)
+      local __host
+      for __host in ${__masters}; do
+        dcos_leader_sanity ${__host} || return $?
+      done
+      return 0 # redundant, but explicit
+    ;;
+    master_snapshot|snapshot)
+      local readonly __masters=$($(pwd -P)/dcos_masters.sh)
+      local __host
+      for __host in ${__masters}; do
+        dcos_master_snapshot_sanity ${__host} || return $?
+      done
+      return 0 # redundant, but explicit
+    ;;
+    zookeeper)
+      local readonly __masters=$($(pwd -P)/dcos_masters.sh)
+      local __host __output __leader=0 __ret=0
+      for __host in ${__masters}; do
+        for __output in $(dcos_zookeeper_sanity ${__host}); do
+          __ret=$?
+          if [[ ${__ret} -ne 0 ]]; then
+            return ${__ret}
+          fi
+          if [[ ${__output} == true ]]; then
+            # We're a leader
+            __leader=1
+          fi
+        done
+      done
+      # At this point, we will have a leader
+      if [[ ${__leader} -ne 1 ]]; then
+        return 1
+      fi
+      return 0 # redundant, but explicit
+    ;;
+  esac
+}
+
+dcos_sanity_check ${@}

--- a/dcos_ssh.sh
+++ b/dcos_ssh.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#
+# dcos_ssh <ip> [command]
+#
+# Performs an SSH to a DC/OS node and runs an optional command
+function dcos_ssh() {
+  local readonly __ip=${1}
+  shift
+  local readonly __command=${@}
+  if [[ ${JUMPHOST_IP} ]]; then
+    local readonly __proxy="--proxy-ip=${JUMPHOST_IP}"
+  fi
+  local readonly __user=${SSH_USER:-${USER}}
+  dcos node ssh \
+    --user=${__user} \
+    ${__proxy} \
+    --option StrictHostKeyChecking=no \
+    --private-ip=${__ip} \
+    "${__command}" | sed 's/Connection to .* closed.//g' | sed 's/\r//g'
+}
+
+dcos_ssh ${@}

--- a/dcos_token.sh
+++ b/dcos_token.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#
+# dcos_token
+#
+# returns DC/OS token from configured cluster
+function dcos_token() { dcos config show core.dcos_acs_token; };
+
+dcos_token

--- a/dcos_wait_for.sh
+++ b/dcos_wait_for.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#
+# dcos_wait_for <type> <count>
+#
+# Poll the DC/OS CLI until the count of the given type is reached
+function dcos_wait_for() {
+  local readonly __type=${1} __count=${2}
+  # We do the awk + second grep to ensure its the correct type
+  until [[ $(dcos node | awk "\$4 ~ /${__type}/ {print \$4}" | wc -w) -eq ${__count} ]]; do
+    sleep 60
+  done
+}
+
+dcos_wait_for ${@}

--- a/runner
+++ b/runner
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+# This script is the runner for node replacements. It's designed to be used
+# fully automated. This script takes a cluster name as the single argument.
+# It assumes that the cluster has already been configured and that the user
+# is "dcos" and the password is in the DCOS_PASSWORD environment variable.
+
+#
+# decho <message>
+#
+# Echoes message to stdout
+function decho() { local readonly __message=${@}; echo "${__message}"; };
+
+#
+# die [message] [exit code]
+#
+# Outputs error message, then exits with the given exit code, or 1
+function die() { local readonly __code=${2:-1}; echo "[ERROR] ${1}" >&2; exit ${__code}; };
+
+#
+# runscript <script> [timeout]
+#
+# Runs a script in this directory, with back-off and timeout
+function runscript() {
+  local readonly __script=${1} __timeout=${2:-60} __bash=bash __backoff=0 __ret=0
+  [[ ${DEBUG} ]] && __bash+=" -x"
+  until ${__bash} $(pwd -P)/${__script} || [[ ${__backoff} -ge ${__timeout} ]]; do
+    sleep $(( __backoff++ ))
+  done
+  __ret=$?
+  if [[ ${__backoff} -ge ${__timeout} ]]; then
+    return 1
+  fi
+  return ${__ret}
+}
+
+# MAIN
+function main() {
+  local __id __node __orig_masters __orig_leader __orig_agents __orig_num_masters __orig_num_agents
+  local __result __ret __zones __zone __agents __check
+  # Enable debug output if DEBUG
+  [[ ${DEBUG} ]] && set -x
+  # Sanity
+  decho
+  decho "Starting replacement for $(dcos config show cluster.name) at $(date -u)"
+  decho
+  decho "Starting initial cluster sanity check"
+  for __check in cockroachdb leader master_snapshot zookeeper; do
+    runscript "dcos_sanity_check.sh ${__check}" || die "Failed polling for ${__check}"
+    decho "[x] ${__check} is healthy"
+  done
+  # Backup
+  ### TODO: uncomment
+  #decho "Starting DC/OS backup (Marathon state)"
+  #runscript dcos_backup.sh || die "Failed to backup Marathon state, code: ${?}" ${?}
+  #decho "[x] Backup successful"
+  # Save existing cluster state
+  __orig_masters=( $(runscript dcos_masters.sh) )
+  __orig_leader=$(runscript dcos_leader.sh)
+  __orig_agents=( $(runscript dcos_agents.sh) )
+  __orig_num_masters=${#__orig_masters[@]}
+  __orig_num_agents=${#__orig_agents[@]}
+  decho
+  decho "Original cluster"
+  decho "================"
+  decho "Masters: ${__orig_num_masters} (${__orig_masters[@]})"
+  decho "Leader: ${__orig_leader}"
+  decho "Agents: ${__orig_num_agents} (${__orig_agents[@]})"
+  decho
+  # Remove non-leader masters
+  decho "Replacing non-leader masters"
+  for __node in ${__orig_masters[@]}; do
+    if [[ ${__node} == ${__orig_leader} ]]; then
+      decho "Skipping ${__node} replacement, current leader"
+      continue # skip leader
+    fi
+    decho
+    decho "Replacing ${__node}"
+    runscript "aws_terminate.sh ${__node}" || die "Instance ${__node} failed to terminate within timeout"
+    decho "Waiting for new node to replace ${__node}"
+    runscript "dcos_wait_for.sh master ${__orig_num_masters}" || die "Failed waiting for ${__orig_num_masters} masters"
+    for __check in cockroachdb leader master_snapshot zookeeper; do
+      runscript "dcos_sanity_check.sh ${__check}" || die "Failed polling for ${__check}"
+      decho "[x] ${__check} is healthy"
+    done
+  done
+  decho
+  decho "Replacing ${__node} (leader)"
+  runscript "aws_terminate.sh ${__orig_leader}" || die "Instance ${__node} (leader) failed to terminate within timeout"
+  decho "Waiting for new node to replace ${__node}"
+  runscript "dcos_wait_for.sh master ${__orig_num_masters}"
+  for __check in cockroachdb leader master_snapshot zookeeper; do
+    runscript "dcos_sanity_check.sh ${__check}" || die "Failed polling for ${__check}"
+    decho "[x] ${__check} is healthy"
+  done
+  decho
+  decho "[x] Master nodes replaced"
+  decho
+  # Remove agents
+  decho "Fetching cluster zones for agents"
+  __zones=$(runscript dcos_cluster_zones.sh)
+  decho "Using these zones:"
+  decho "${__zones}"
+  decho
+  for __zone in ${__zones}; do
+    # Get list of agents in this zone
+    __agents=$(runscript "dcos_agents_by_zone.sh ${__zone}")
+    for __host in ${__agents}; do
+      decho "Terminating ${__host} in ${__zone}"
+      runscript "aws_terminate.sh ${__host}" || die "Instance ${__node} failed to terminate within timeout"
+      runscript "dcos_decommission_agent.sh ${__host}" || die "Failed decommission on ${__node}"
+    done
+    # Poll until new nodes are in agent list
+    decho "Polling for agents to rejoin cluster"
+    runscript "dcos_wait_for.sh agent ${__orig_num_agents}" || die "Failed waiting for ${__orig_num_agents} to rejoin cluster"
+    # Wait for agent registration
+    runscript "dcos_sanity_check.sh agent_snapshot" || die "Failed polling for agent_snapshot"
+    decho "[x] Zone ${__zone} completed"
+    decho
+  done
+  decho "Successfully replaced all nodes at $(date -u)"
+  decho
+  __new_masters=( $(runscript dcos_masters.sh) )
+  __new_leader=$(runscript dcos_leader.sh)
+  __new_agents=( $(runscript dcos_agents.sh) )
+  __new_num_masters=${#__new_masters[@]}
+  __new_num_agents=${#__new_agents[@]}
+  decho
+  decho "New cluster"
+  decho "================"
+  decho "Masters: ${__new_num_masters} (${__new_masters[@]})"
+  decho "Leader: ${__new_leader}"
+  decho "Agents: ${__new_num_agents} (${__new_agents[@]})"
+  decho
+}
+
+# do MAIN
+main


### PR DESCRIPTION
This is a set of scripts to automate the process of replacing nodes
in a DC/OS cluster. This is a first pass at the code, allowing us to
perform simple replacements on clusters with all HA services and no
persistent services deployed.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>