### PR TITLE
Make waiting for termination configurable

### DIFF
--- a/aws_terminate.sh
+++ b/aws_terminate.sh
@@ -57,10 +57,10 @@ function aws_terminate() {
   elif [[ ${__ret} -ne 0 ]]; then
     return ${__ret}
   fi
-  if [[ ${DEBUG} ]]; then
+  if [[ ${AWS_TERMINATE_WAIT} ]]; then
     aws_until_state terminated ${__id} ${__timeout} || return $?
   else
-    sleep 3 # slight sleep to reduce errors
+    sleep 3 # slight wait between nodes
   fi
   return
 }

--- a/runner
+++ b/runner
@@ -69,6 +69,8 @@ function main() {
   decho
   # Remove non-leader masters
   decho "Replacing non-leader masters"
+  # Enable waiting for termination
+  export AWS_TERMINATE_WAIT=true
   for __node in ${__orig_masters[@]}; do
     if [[ ${__node} == ${__orig_leader} ]]; then
       decho "Skipping ${__node} replacement, current leader"
@@ -96,6 +98,8 @@ function main() {
   decho
   decho "[x] Master nodes replaced"
   decho
+  # Disable waiting for termination
+  unset AWS_TERMINATE_WAIT
   # Remove agents
   decho "Fetching cluster zones for agents"
   __zones=$(runscript dcos_cluster_zones.sh)


### PR DESCRIPTION
The DC/OS Master nodes should be done fully serially, so ensure the node
is completely shut down before proceeding. Otherwise, cluster health
checks occur before the node goes down, making it healthy, and the
script continues to the next master, breaking quorum. This code still
allows the slave nodes to be dropped without waiting for termination, so
they go down nearly at once and replacement is a bit faster.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>